### PR TITLE
fix bug in cli

### DIFF
--- a/backend/src/grouter/cli.c
+++ b/backend/src/grouter/cli.c
@@ -654,7 +654,7 @@ void gncCmd() {
         return;
 
     // TCP
-    if (strcmp(next_tok, "-u") != 0) {
+    if (strcmp(next_tok, "-u") != 0 && strcmp(next_tok, "-r") != 0) {
 
         // gnc -l <port>
         if (!strcmp(next_tok, "-l")) {


### PR DESCRIPTION
didn't include the condition to check "-r", otherwise when I run "gnc -r -l 5000" I will receive "tcp error 1"